### PR TITLE
Bump rembg to 2.0.38, support DIS models

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,7 +1,7 @@
 import launch
 
 if not launch.is_installed("rembg"):
-    launch.run_pip("install rembg==2.0.30 --no-deps", "rembg")
+    launch.run_pip("install rembg==2.0.38 --no-deps", "rembg")
 
 for dep in ['onnxruntime', 'pymatting', 'pooch']:
     if not launch.is_installed(dep):

--- a/scripts/postprocessing_rembg.py
+++ b/scripts/postprocessing_rembg.py
@@ -11,6 +11,8 @@ models = [
     "u2net_human_seg",
     "u2net_cloth_seg",
     "silueta",
+    "isnet-general-use",
+    "isnet-anime",
 ]
 
 class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):


### PR DESCRIPTION
Yet another version bump PR. This time to support both DIS models, one for [general use](https://github.com/xuebinqin/DIS), and another for [anime](https://github.com/SkyTNT/anime-segmentation).
Supersedes https://github.com/AUTOMATIC1111/stable-diffusion-webui-rembg/pull/11 and https://github.com/AUTOMATIC1111/stable-diffusion-webui-rembg/pull/19.