### PR TITLE
Update rembg dependency and add BiRefNet models in the list of available RemBG models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.vscode

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Extension for [webui](https://github.com/AUTOMATIC1111/stable-diffusion-webui). 
 
 Find the UI for rembg in the Extras tab after installing the extension.
 
+You'll be able to select the following models:
+- "Classic" models: inference is fast, result is good.
+- "BiRefNet" models: inference may take more time but result might be better.
+
 # Installation
 
 Install from webui's Extensions tab.

--- a/install.py
+++ b/install.py
@@ -1,7 +1,19 @@
 import launch
+from importlib import metadata
 
-if not launch.is_installed("rembg"):
-    launch.run_pip("install rembg==2.0.50 --no-deps", "rembg")
+
+rembg_expected_version = "2.0.59"
+
+
+try:
+    rembg_installed_version = metadata.version("rembg")
+except Exception:
+    rembg_installed_version = None
+
+
+if rembg_installed_version != rembg_expected_version:
+    launch.run_pip(f"install rembg=={rembg_expected_version} --no-deps", "rembg")
+
 
 for dep in ['onnxruntime', 'pymatting', 'pooch']:
     if not launch.is_installed(dep):

--- a/scripts/api.py
+++ b/scripts/api.py
@@ -7,12 +7,20 @@ import gradio as gr
 import rembg
 
 # models = [
-#     "None",
 #     "u2net",
 #     "u2netp",
 #     "u2net_human_seg",
 #     "u2net_cloth_seg",
 #     "silueta",
+#     "isnet-general-use",
+#     "isnet-anime",
+#     "birefnet-general",
+#     "birefnet-general-lite",
+#     "birefnet-portrait",
+#     "birefnet-dis",
+#     "birefnet-hrsod",
+#     "birefnet-cod",
+#     "birefnet-massive",
 # ]
 
 
@@ -34,7 +42,7 @@ def rembg_api(_: gr.Blocks, app: FastAPI):
 
         image = rembg.remove(
             input_image,
-            session=rembg.new_session(model),
+            session=rembg.new_session(model, providers=['CUDAExecutionProvider', 'CPUExecutionProvider']),
             only_mask=return_mask,
             alpha_matting=alpha_matting,
             alpha_matting_foreground_threshold=alpha_matting_foreground_threshold,

--- a/scripts/postprocessing_rembg.py
+++ b/scripts/postprocessing_rembg.py
@@ -1,14 +1,12 @@
 from modules import scripts_postprocessing, ui_components
 import gradio as gr
 
-from modules.ui_components import FormRow
 from modules.paths_internal import models_path
 import rembg
 import os
 
 models = [
     "None",
-    "isnet-general-use",
     "u2net",
     "u2netp",
     "u2net_human_seg",
@@ -16,6 +14,17 @@ models = [
     "silueta",
     "isnet-general-use",
     "isnet-anime",
+]
+
+birefnet_models = [
+    "None",
+    "birefnet-general",
+    "birefnet-general-lite",
+    "birefnet-portrait",
+    "birefnet-dis",
+    "birefnet-hrsod",
+    "birefnet-cod",
+    "birefnet-massive",
 ]
 
 class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
@@ -26,6 +35,9 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
     def ui(self):
         with ui_components.InputAccordion(False, label="Remove background") as enable:
             with gr.Row():
+                model_type = gr.Radio(["Classic", "BiRefNet"], value="Classic", label="Model type")
+
+            with gr.Row():
                 model = gr.Dropdown(label="Remove background", choices=models, value="None")
                 return_mask = gr.Checkbox(label="Return mask", value=False)
                 alpha_matting = gr.Checkbox(label="Alpha matting", value=False)
@@ -34,6 +46,12 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
                 alpha_matting_erode_size = gr.Slider(label="Erode size", minimum=0, maximum=40, step=1, value=10)
                 alpha_matting_foreground_threshold = gr.Slider(label="Foreground threshold", minimum=0, maximum=255, step=1, value=240)
                 alpha_matting_background_threshold = gr.Slider(label="Background threshold", minimum=0, maximum=255, step=1, value=10)
+
+            model_type.change(
+                fn=lambda x: gr.update(value="None", choices=birefnet_models if x == "BiRefNet" else models),
+                inputs=[model_type],
+                outputs=[model],
+            )
 
             alpha_matting.change(
                 fn=lambda x: gr.update(visible=x),
@@ -63,7 +81,7 @@ class ScriptPostprocessingUpscale(scripts_postprocessing.ScriptPostprocessing):
 
         pp.image = rembg.remove(
             pp.image,
-            session=rembg.new_session(model),
+            session=rembg.new_session(model, providers=['CUDAExecutionProvider', 'CPUExecutionProvider']),
             only_mask=return_mask,
             alpha_matting=alpha_matting,
             alpha_matting_foreground_threshold=alpha_matting_foreground_threshold,


### PR DESCRIPTION
Hi,

The goal of this PR is to add [BiRefNet](https://github.com/ZhengPeng7/BiRefNet) models to the list of available remove background models. It follows discussion [here](https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/16033) and merged PR in rembg [here](https://github.com/danielgatis/rembg/pull/665).

The following modifications have been made:
- Force installation of the latest 2.0.59 version of `rembg` even if a previous one was already installed.
- Add of a radio button allowing users to select either "Classic" models (it's the defaut option, which allows to use the same models as before my modifications) or "BiRefNet" models:

![image](https://github.com/user-attachments/assets/8f478430-a356-46be-bb55-fc58ee83a494)

- Remove duplicate `isnet-general-use` entry from the list of classic models.
- Add parameter `providers` when calling `rembg` from UI or API with only `CUDAExecutionProvider` and `CPUExecutionProvider` as by default all available providers may be used, for instance `TensorrtExecutionProvider` or `AzureExecutionProvider`, even if no external dependency is installed with this extension, leading to an error message in the console. Internally, `rembg` will remove `CUDAExecutionProvider` from its list of providers if it's not an available provider (cf. [here](https://github.com/danielgatis/rembg/blob/main/rembg/sessions/base.py#L26)).
- Update README file accordingly to this PR modifications.
- Add .vscode folder to .gitignore to avoid development environment configuration pollution.

Please let me know if I need to make any changes.